### PR TITLE
upgrade to current x25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ exclude = [
 rayon = "1.0"
 base64 = "0.10"
 rand = "0.6.0"
-x25519-dalek = { version = "0.3", default-features = false, features = ["std", "u64_backend"] }
+x25519-dalek = { version = "0.4.4", default-features = false, features = ["std", "u64_backend"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ fn main() {
             let mut rng = thread_rng();
             let mut private = [0u8; 32];
             rng.try_fill_bytes(&mut private).unwrap();
+            private[0] &= 248;
+            private[31] &= 127;
+            private[31] |= 64;
             let public = x25519(private, X25519_BASEPOINT_BYTES);
             let public_b64 = base64::encode(&public);
             //if public_b64.starts_with(&prefix) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,10 @@ extern crate rand;
 extern crate rayon;
 extern crate x25519_dalek;
 
-use rand::thread_rng;
+use rand::{thread_rng, RngCore};
 use rayon::prelude::*;
 use std::env;
-use x25519_dalek as x25519;
+use x25519_dalek::{x25519, X25519_BASEPOINT_BYTES};
 
 fn main() {
     let prefix = env::args().nth(1).unwrap().to_ascii_lowercase();
@@ -24,8 +24,9 @@ fn main() {
         .into_par_iter()
         .map(|_| {
             let mut rng = thread_rng();
-            let private = x25519::generate_secret(&mut rng);
-            let public = x25519::generate_public(&private).to_bytes();
+            let mut private = [0u8; 32];
+            rng.try_fill_bytes(&mut private).unwrap();
+            let public = x25519(private, X25519_BASEPOINT_BYTES);
             let public_b64 = base64::encode(&public);
             //if public_b64.starts_with(&prefix) {
             if public_b64[..WITHIN].to_ascii_lowercase().contains(&prefix) {
@@ -38,6 +39,7 @@ fn main() {
             } else {
                 false
             }
-        }).filter(|good| *good)
+        })
+        .filter(|good| *good)
         .collect();
 }


### PR DESCRIPTION
The latest x25519-dalek removes access to the internal scalar of secret-key
objects (no EphemeralSecret.as_bytes), so instead we must use the low-level
x25519() function on a slice of bytes. These bytes are unclamped, whereas
previously the private keys we printed were clamped, so we're depending upon
Wireguard to clamp the private-key scalars it reads from the config file.