### PR TITLE
Add Dockerfile to the repo to build wireguard-vanity-address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile to build wireguard-vanity-address
+# from https://github.com/LukeMathWalker/cargo-chef
+
+# Build with docker build -t wgvanity .
+# Invoke with docker run wgvanity [ string ]
+
+FROM lukemathwalker/cargo-chef:latest-rust-1.56.0 AS chef
+WORKDIR app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --bin wireguard-vanity-address
+
+# We do not need the Rust toolchain to run the binary!
+FROM debian:buster-slim AS runtime
+WORKDIR app
+COPY --from=builder /app/target/release/wireguard-vanity-address /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/wireguard-vanity-address"]
+CMD ["Rich"] # default is "Rich"; supply your own string as a parameter

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Build with docker build -t wgvanity .
 # Invoke with docker run wgvanity [ string ]
 
-FROM lukemathwalker/cargo-chef:latest-rust-1.56.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR app
 
 FROM chef AS planner

--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ search string, and don't try too hard to find a perfect pubkey. You only need
 something distinctive enough distinguish between a handful of VPN targets in
 a status display.
 
+## Dockerfile
+
+This repo contains a Dockerfile for running the binary so you
+don't have to install rust or other build tools.
+To use it:
+
+```
+docker build -t wgvanity .       # to build the container
+
+docker run wgvanity [ string ]   # optional string for the "vanity address"
+```
+After you find a suitable public key (with a good vanity address),
+you will need to stop the docker container by opening a new terminal session and entering: 
+
+```
+docker ps                    # to find the currently-running container
+docker stop container_name   # to stop it
+```
 ## License
 
 This is distributed under the MIT license, see [LICENSE](LICENSE.md) for

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ don't have to install rust or other build tools.
 To use it:
 
 ```
-docker build -t wgvanity .       # to build the container
+docker build -t wgvanity .          # to build the container
 
-docker run wgvanity [ string ]   # optional string for the "vanity address"
+docker run --rm wgvanity "string"   # string for the "vanity address"
 ```
 After you find a suitable public key (with a good vanity address),
 you will need to stop the docker container by opening a new terminal session and entering: 
@@ -122,5 +122,5 @@ docker stop container_name   # to stop it
 ```
 ## License
 
-This is distributed under the MIT license, see [LICENSE](LICENSE.md) for
-details.
+This is distributed under the MIT license,
+see [LICENSE](LICENSE.md) for details.

--- a/README.md
+++ b/README.md
@@ -111,15 +111,11 @@ To use it:
 ```
 docker build -t wgvanity .          # to build the container
 
-docker run --rm wgvanity "string"   # string for the "vanity address"
+docker run --rm --init -it wgvanity "string"   # string for the "vanity address"
 ```
 After you find a suitable public key (with a good vanity address),
-you will need to stop the docker container by opening a new terminal session and entering: 
+hit Control-C to abort 
 
-```
-docker ps                    # to find the currently-running container
-docker stop container_name   # to stop it
-```
 ## License
 
 This is distributed under the MIT license,


### PR DESCRIPTION
For whatever reason, I had trouble building `wireguard-vanity-address` on macOS, so I had to spin up one of my Linux VMs to run it. I love this program [and blogged about it.](https://randomneuronsfiring.com/wireguard-vanity-keys/)

I read Jonathan Bergknoff’s [Run More Stuff in Docker](https://jonathan.bergknoff.com/journal/run-more-stuff-in-docker/) that made a lot of sense to me. (The magic of using Docker is that once you’ve created the instance, all the tool and dependency versions remain the same. It’s easy then to hand the Dockerfile to a colleague who can build an identical development environment in a few minutes. It also avoids cluttering my daily-driver laptop with multiple versions of Node, npm, Go, Python, rust, and any number of little-used tooling – they’re all encapsulated in the Docker container.)

So I offer up this Dockerfile for your readers. Thanks again for writing `wireguard-vanity-address`!